### PR TITLE
[🐸 Frogbot] Update Maven dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,21 +17,21 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.9</version> <!-- Vulnerable version -->
+            <version>3.18.0</version> <!-- Vulnerable version -->
         </dependency>
 
         <!-- Example of another dependency with a known vulnerability -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
-            <version>5.2.0.RELEASE</version> <!-- Vulnerable version -->
+            <version>5.2.19.RELEASE</version> <!-- Vulnerable version -->
         </dependency>
 
         <!-- A transitive dependency might introduce vulnerabilities as well -->
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>5.3.7.Final</version> <!-- Vulnerable version -->
+            <version>5.3.20.Final</version> <!-- Vulnerable version -->
         </dependency>
 
         <!-- An example of a persistent security issue in older versions -->


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![high](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableHighSeverity.png)<br>    High | CVE-2020-25638 | Missing Context | org.hibernate:hibernate-core:5.3.7.Final | org.hibernate:hibernate-core 5.3.7.Final | [5.3.20.Final]<br>[5.4.24.Final] |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2021-22060 | Applicable | org.springframework:spring-core:5.2.0.RELEASE | org.springframework:spring-core 5.2.0.RELEASE | [5.2.19.RELEASE]<br>[5.3.14] |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2025-48924 | Not Covered | org.apache.commons:commons-lang3:3.9 | org.apache.commons:commons-lang3 3.9 | [3.18.0] |

</div>


### 🔖 Details


<details><summary><b>[ CVE-2020-25638 ] org.hibernate:hibernate-core 5.3.7.Final (orz_watch)</b></summary>

### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy_with_fail_pr |
| **Watch Name:** | orz_watch |
| **Contextual Analysis:** | Missing Context |
| **Direct Dependencies:** | org.hibernate:hibernate-core:5.3.7.Final |
| **Impacted Dependency:** | org.hibernate:hibernate-core:5.3.7.Final |
| **Fixed Versions:** | [5.3.20.Final], [5.4.24.Final] |
| **CVSS V3:** | 7.4 |

A flaw was found in hibernate-core in versions prior to and including 5.4.23.Final. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks. The highest threat from this vulnerability is to data confidentiality and integrity.<br></details>

<details><summary><b>[ CVE-2021-22060 ] org.springframework:spring-core 5.2.0.RELEASE (orz_watch)</b></summary>

### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy_with_fail_pr |
| **Watch Name:** | orz_watch |
| **Jfrog Research Severity:** | <img src="https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/smallMedium.svg" alt=""/> Medium |
| **Contextual Analysis:** | Applicable |
| **Direct Dependencies:** | org.springframework:spring-core:5.2.0.RELEASE |
| **Impacted Dependency:** | org.springframework:spring-core:5.2.0.RELEASE |
| **Fixed Versions:** | [5.2.19.RELEASE], [5.3.14] |
| **CVSS V3:** | 4.3 |

Missing control character sanitization in Spring Framework can lead to log injection when logging a crafted payload.

### 🔬 JFrog Research Details

**Description:**
The [Spring Framework](https://spring.io/) is a widely used Java-based application framework that provides infrastructure support for the development of enterprise-level Java applications.
This CVE is a follow-up to CVE-2021-22096, which allowed newline characters in log entries due to missing string sanitization. Another issue has been identified in the `formatValue()` function of the `LogFormatUtils` class, where control characters are not sanitized. This can lead to log injection that can hide parts of the original log, which attackers can exploit to hide their attacks against the Spring Framework. A [technical write-up](https://psytester.github.io/log_injection/) demonstrates that some logs in the WARN level, enabled by default, are vulnerable to this CVE. 

For example - sending a request with encoded backspace characters such as `https://my-hostname/api/RealPath/logentryInjectionWithNewlineAndBackspaces%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08%08/FakedPathForLogging`

Will modify Spring's log and incorrectly show that the request was performed against the endpoint `/FakedPathForLogging` instead of the real endpoint `/RealPath/logentryInjectionWithNewlineAndBackspaces`

It is important to note that formatValue() is primarily for internal use.
<br></details>

<details><summary><b>[ CVE-2025-48924 ] org.apache.commons:commons-lang3 3.9 (orz_watch)</b></summary>

### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | policy_with_fail_pr |
| **Watch Name:** | orz_watch |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | org.apache.commons:commons-lang3:3.9 |
| **Impacted Dependency:** | org.apache.commons:commons-lang3:3.9 |
| **Fixed Versions:** | [3.18.0] |
| **CVSS V3:** | 6.5 |

Uncontrolled Recursion vulnerability in Apache Commons Lang.

This issue affects Apache Commons Lang: Starting with commons-lang:commons-lang 2.0 to 2.6, and, from org.apache.commons:commons-lang3 3.0 before 3.18.0.

The methods ClassUtils.getClass(...) can throw StackOverflowError on very long inputs. Because an Error is usually not handled by applications and libraries, a 
StackOverflowError could cause an application to stop.

Users are recommended to upgrade to version 3.18.0, which fixes the issue.<br></details>


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>


[comment]: <> (Checksum: 86a9f9ac91ae6bedcc9b7b4f60ab2c7b)
