### PR TITLE
[🐸 Frogbot] Update version of org.owasp.antisamy:antisamy to 1.7.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.owasp.antisamy</groupId>
             <artifactId>antisamy</artifactId>
-            <version>1.5.7</version> <!-- Vulnerable version (CVE-2021-22988) -->
+            <version>1.7.5</version> <!-- Vulnerable version (CVE-2021-22988) -->
         </dependency>
         <dependency>
             <groupId>org.apache.shiro</groupId>


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2024-23635 | Not Covered | org.owasp.antisamy:antisamy:1.5.7 | org.owasp.antisamy:antisamy 1.5.7 | [1.7.5] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | project-key-jas-violations-policy-macOS-sec-test-1759914900 |
| **Watch Name:** | project-key-jas-violations-watch-macOS-sec-test-1759914900 |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | org.owasp.antisamy:antisamy:1.5.7 |
| **Impacted Dependency:** | org.owasp.antisamy:antisamy:1.5.7 |
| **Fixed Versions:** | [1.7.5] |
| **CVSS V3:** | 6.1 |

AntiSamy is a library for performing fast, configurable cleansing of HTML coming from untrusted sources. Prior to 1.7.5, there is a potential for a mutation XSS (mXSS) vulnerability in AntiSamy caused by flawed parsing of the HTML being sanitized. To be subject to this vulnerability the `preserveComments` directive must be enabled in your policy file. As a result, certain crafty inputs can result in elements in comment tags being interpreted as executable when using AntiSamy's sanitized output. Patched in AntiSamy 1.7.5 and later.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
