### PR TITLE
[🐸 Frogbot] Update version of com.thoughtworks.xstream:xstream to 1.4.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
-            <version>1.4.9</version> <!-- Vulnerable version (CVE-2020-26247) -->
+            <version>1.4.21</version> <!-- Vulnerable version (CVE-2020-26247) -->
         </dependency>
 
         <!-- Updated version of Spring Framework Core -->


### PR DESCRIPTION


[comment]: <> (FrogbotReviewComment)

<div align='center'>

[![🚨 This automated pull request was created by Frogbot and fixes the below:](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/vulnerabilitiesFixBannerPR.png)](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>



### 📦 Vulnerable Dependencies

<div align='center'>

| Severity                | ID                  | Contextual Analysis                  | Direct Dependencies                  | Impacted Dependency                  | Fixed Versions                  |
| :---------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: | :-----------------------------------: |
| ![medium](https://raw.githubusercontent.com/jfrog/frogbot/master/resources/v2/applicableMediumSeverity.png)<br>  Medium | CVE-2021-39140 | Not Covered | com.thoughtworks.xstream:xstream:1.4.9 | com.thoughtworks.xstream:xstream 1.4.9 | [1.4.18] |

</div>


### 🔖 Details



### Vulnerability Details
|                 |                   |
| --------------------- | :-----------------------------------: |
| **Policies:** | project-key-jas-violations-policy-macOS-sec-test-1759914900 |
| **Watch Name:** | project-key-jas-violations-watch-macOS-sec-test-1759914900 |
| **Contextual Analysis:** | Not Covered |
| **Direct Dependencies:** | com.thoughtworks.xstream:xstream:1.4.9 |
| **Impacted Dependency:** | com.thoughtworks.xstream:xstream:1.4.9 |
| **Fixed Versions:** | [1.4.18] |
| **CVSS V3:** | 6.3 |

XStream is a simple library to serialize objects to XML and back again. In affected versions this vulnerability may allow a remote attacker to allocate 100% CPU time on the target system depending on CPU type or parallel execution of such a payload resulting in a denial of service only by manipulating the processed input stream. No user is affected, who followed the recommendation to setup XStream's security framework with a whitelist limited to the minimal required types. XStream 1.4.18 uses no longer a blacklist by default, since it cannot be secured for general purpose.


---
<div align='center'>

[🐸 JFrog Frogbot](https://docs.jfrog-applications.jfrog.io/jfrog-applications/frogbot)

</div>
